### PR TITLE
v1.4.0-rc.1

### DIFF
--- a/CalculateEmissionFactors.Rmd
+++ b/CalculateEmissionFactors.Rmd
@@ -4,10 +4,10 @@ output:
   md_document:
     variant: gfm
 params:
-  dollaryear: 2022
+  dollaryear: 2023
 ---
 
-Generate supply chain GHG emission factors for NAICS-6 Commodities using 2022 GHG data in CO2-equivalent and by gas.
+Generate supply chain GHG emission factors for NAICS-6 Commodities using 2023 GHG data in CO2-equivalent and by gas.
 
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = FALSE)
@@ -20,7 +20,7 @@ library(kableExtra)
 price_adjust_matrices <- c("B", "D", "M", "N", "M_margin", "N_margin")
 MajorGHGs <- c("Carbon dioxide", "Methane", "Nitrous oxide")
 dollaryear <- params$dollaryear
-modelname <- "USEEIOv2.2.22-GHG"
+modelname <- "USEEIOv2.5.1-phoebe-23"
 checkModelIOYear(modelname)
 ```
 
@@ -86,7 +86,7 @@ MEF_df <- generateEmissionFactorTable(model, price_adjusted_model, margin = TRUE
 # Combine SEF and MEF tables
 df <- cbind(SEF_df, MEF_df[, "FlowAmount"], SEF_df[, "FlowAmount"] + MEF_df[, "FlowAmount"])
 
-# Filter only to include records which used the GWP-AR4-100 indicator
+# Filter only to include records which used the GWP-AR6-100 indicator
 table_characterized <- df[df$Flowable == "All GHGs", ]
 
 table_characterized <- prepareSEFtable(table_characterized,factorform="Decimal Form")

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 U.S. EPA
+Copyright (c) 2025 Cornerstone Sustainability Data Initiative
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/R/utils.R
+++ b/R/utils.R
@@ -18,14 +18,14 @@ install_useeior <- function(SEF_version) {
   }
   if (!"useeior"%in%installed_pkg[, "Package"]) {
     cli::cli_alert_info("Installing useeior v{useeior_ver} (tag @{useeior_tag}) from GitHub...")
-    devtools::install_github(paste0("USEPA/useeior@", useeior_tag))
+    devtools::install_github(paste0("cornerstone-data/useeior@", useeior_tag))
   }
   installed_useeior_ver <- installed_pkg[installed_pkg[, "Package"]=="useeior", "Version"]
   if ("useeior"%in%installed_pkg[, "Package"] && useeior_ver!=installed_useeior_ver) {
     cli::cli_alert_warning(c("A new version of useeior (v{useeior_ver}) will be installed for generating SEF {SEF_version}. ",
                              "The useeior v{installed_useeior_ver} you have installed will be overwritten."))
     cli::cli_alert_info("Installing useeior v{useeior_ver} (tag @{useeior_tag}) from GitHub...")
-    devtools::install_github(paste0("USEPA/useeior@", useeior_tag))
+    devtools::install_github(paste0("cornerstone-data/useeior@", useeior_tag))
   }
 }
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -6,20 +6,16 @@ output:
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
-# Supply Chain GHG Emission Factors
-Code to produce the most recent version of the [Supply Chain GHG Emission Factors](https://cfpub.epa.gov/si/si_public_record_Report.cfm?dirEntryId=349324).
-Code to produce older versions can be found in [releases](/releases), where the release version number corresponds with Supply Chain GHG Emission Factors dataset version.
+# Supply Chain GHG Emission Factors - Cornerstone
+
+This code builds on the USEPA published code to produce a version of the [Supply Chain GHG Emission Factors](https://cfpub.epa.gov/si/si_public_record_Report.cfm?dirEntryId=349324) using the USEEIO model.
 
 Watch this [EPA webinar](https://www.youtube.com/watch?v=pJ8gvZPdcgc) to understand how to produce the Factors and how to use them for organizational GHG reporting.
-
-Check out [Discussions](https://github.com/USEPA/supply-chain-factors/discussions) for FAQs.
-If you don't see your questions in it, feel free to post them.
-If you want answer a posted question or add comments to a question, you are welcome to submit them.
 
 ## Software and Hardware Requirements
 1. [R](https://www.r-project.org/) software, version >= 3.6
 2. A Windows, Mac, or Linux computer with an Internet connection and permissions set to install R packages and write files to a local project folder.
-3. A local version of this repository, preferably a [release](https://github.com/USEPA/supply-chain-factors/releases) version to create EPA-verified factors.
+3. A local version of this repository, preferably a [release](https://github.com/cornerstone-data/supply-chain-factors/releases) version to create factors.
 
 ### Optional Requirements
 1. [Git](https://github.com/git-guides/install-git), if users wish to clone the code from this repository using Git, instead of downloading a zip file of the code.
@@ -44,5 +40,4 @@ rmarkdown::render("CalculateEmissionFactors.Rmd", params = "ask")
 In both cases a comma-separated file of the supply chain factors will be written out in the main folder of the project, with a name like *SupplyChainGHGEmissionFactors_[...].csv* based on the options selected by the user and matches one of the [model specifications](model-specs/) stored in this project.
 The fields used to defined data are described in the [format specifications](format-specs/). A markdown file, CalculateEmissionFactors.md, is automatically generated during execution, but it contains no original content.
 
-# Disclaimer
-The United States Environmental Protection Agency (EPA) GitHub project code is provided on an "as is" basis and the user assumes responsibility for its use. EPA has relinquished control of the information and no longer has responsibility to protect the integrity , confidentiality, or availability of the information. Any reference to specific commercial products, processes, or services by service mark, trademark, manufacturer, or otherwise, does not constitute or imply their endorsement, recommendation or favoring by EPA. The EPA seal and logo shall not be used in any manner to imply endorsement of any commercial product or activity by EPA or the United States Government.
+

--- a/README.md
+++ b/README.md
@@ -1,21 +1,15 @@
-# Supply Chain GHG Emission Factors
-Code to produce the most recent version of the [Supply Chain GHG
-Emission Factors](https://cfpub.epa.gov/si/si_public_record_Report.cfm?dirEntryId=349324).
-Code to produce older versions can be found in [releases](https://github.com/USEPA/supply-chain-factors/releases),
-where the release version number corresponds with Supply Chain GHG
-Emission Factors dataset version.
+<!-- README.md is generated from README.Rmd. Please edit that file -->
+
+# Supply Chain GHG Emission Factors - Cornerstone
+
+This code builds on the USEPA published code to produce a version of the
+[Supply Chain GHG Emission
+Factors](https://cfpub.epa.gov/si/si_public_record_Report.cfm?dirEntryId=349324)
+using the USEEIO model.
 
 Watch this [EPA webinar](https://www.youtube.com/watch?v=pJ8gvZPdcgc) to
 understand how to produce the Factors and how to use them for
 organizational GHG reporting.
-
-Check out
-[Discussions](https://github.com/USEPA/supply-chain-factors/discussions)
-for FAQs. If you don’t see your questions in it, feel free to post them.
-If you want answer a posted question or add comments to a question, you
-are welcome to submit them.
-
-Note that this site is NOT intended to provide guidance on GHG reporting, but rather a resource that might be used in a an estimation of GHG emissions from purchased goods and services.
 
 ## Software and Hardware Requirements
 
@@ -24,8 +18,8 @@ Note that this site is NOT intended to provide guidance on GHG reporting, but ra
     permissions set to install R packages and write files to a local
     project folder.
 3.  A local version of this repository, preferably a
-    [release](https://github.com/USEPA/supply-chain-factors/releases)
-    version to create EPA-verified factors.
+    [release](https://github.com/cornerstone-data/supply-chain-factors/releases)
+    version to create factors.
 
 ### Optional Requirements
 
@@ -70,16 +64,3 @@ stored in this project. The fields used to defined data are described in
 the [format specifications](format-specs/). A markdown file,
 CalculateEmissionFactors.md, is automatically generated during
 execution, but it contains no original content.
-
-# Disclaimer
-
-The United States Environmental Protection Agency (EPA) GitHub project
-code is provided on an “as is” basis and the user assumes responsibility
-for its use. EPA has relinquished control of the information and no
-longer has responsibility to protect the integrity , confidentiality, or
-availability of the information. Any reference to specific commercial
-products, processes, or services by service mark, trademark,
-manufacturer, or otherwise, does not constitute or imply their
-endorsement, recommendation or favoring by EPA. The EPA seal and logo
-shall not be used in any manner to imply endorsement of any commercial
-product or activity by EPA or the United States Government.

--- a/Versioning.yml
+++ b/Versioning.yml
@@ -11,5 +11,5 @@ v1.3.0:
   useeior_tag: "v1.5.3"
   useeior_ver: "1.5.3"
 v1.4.0:
-  useeior_tag: "waste_disagg_update"
-  useeior_ver: "1.7.2"
+  useeior_tag: "v1.8.0"
+  useeior_ver: "1.8.0"

--- a/Versioning.yml
+++ b/Versioning.yml
@@ -10,3 +10,6 @@ v1.2.3:
 v1.3.0:
   useeior_tag: "v1.5.3"
   useeior_ver: "1.5.3"
+v1.4.0:
+  useeior_tag: "v1.7.1"
+  useeior_ver: "1.7.1"

--- a/Versioning.yml
+++ b/Versioning.yml
@@ -11,5 +11,5 @@ v1.3.0:
   useeior_tag: "v1.5.3"
   useeior_ver: "1.5.3"
 v1.4.0:
-  useeior_tag: "v1.7.1"
-  useeior_ver: "1.7.1"
+  useeior_tag: "waste_disagg_update"
+  useeior_ver: "1.7.2"

--- a/model-specs/README.Rmd
+++ b/model-specs/README.Rmd
@@ -41,4 +41,4 @@ options(knitr.table.format = "markdown")
 kableExtra::kable(ModelSummary, row.names = FALSE, align = c("l", rep("r", ncol(ModelSummary)-1)))
 ```
 
-The model specification files use the [useeior Model Specification format](https://github.com/USEPA/useeior/blob/master/format_specs/ModelSpecification.md) pertaining to the `useeior` release version that is being used to generate the factors.
+The model specification files use the [useeior Model Specification format](https://github.com/cornerstone-data/useeior/blob/master/format_specs/ModelSpecification.md) pertaining to the `useeior` release version that is being used to generate the factors.

--- a/model-specs/README.Rmd
+++ b/model-specs/README.Rmd
@@ -17,7 +17,7 @@ library(kableExtra)
 ```
 
 ```{r model-summary, include=FALSE}
-model_specs <- list.files("model-specs")[endsWith(list.files("model-specs"), "GHG.yml")]
+model_specs <- list.files("model-specs")[endsWith(list.files("model-specs"), ".yml")]
 ModelSummary <- data.frame()
 for (modelname in sub(".yml", "", model_specs)) {
   model <- useeior:::initializeModel(modelname,

--- a/model-specs/README.md
+++ b/model-specs/README.md
@@ -4,10 +4,11 @@ Directory of model specifications for these models.
 
 ## Model Descriptions
 
-| Model Name        | \# of Sectors | Commodity (C) or Industry (I) | IO Data Year | GHG and Economic Output Year |
-|:------------------|--------------:|------------------------------:|-------------:|-----------------------------:|
-| USEEIOv2.1.19-GHG |           411 |                     Commodity |         2012 |                         2019 |
-| USEEIOv2.2.22-GHG |           402 |                     Commodity |         2017 |                         2022 |
+| Model Name             | \# of Sectors | Commodity (C) or Industry (I) | IO Data Year | GHG and Economic Output Year |
+|:-----------------------|--------------:|------------------------------:|-------------:|-----------------------------:|
+| USEEIOv2.1.19-GHG      |           411 |                     Commodity |         2012 |                         2019 |
+| USEEIOv2.2.22-GHG      |           402 |                     Commodity |         2017 |                         2022 |
+| USEEIOv2.5.1-phoebe-23 |           402 |                     Commodity |         2017 |                         2023 |
 
 The model specification files use the [useeior Model Specification
 format](https://github.com/USEPA/useeior/blob/master/format_specs/ModelSpecification.md)

--- a/model-specs/README.md
+++ b/model-specs/README.md
@@ -11,6 +11,6 @@ Directory of model specifications for these models.
 | USEEIOv2.5.1-phoebe-23 |           408 |                     Commodity |         2017 |                         2023 |
 
 The model specification files use the [useeior Model Specification
-format](https://github.com/USEPA/useeior/blob/master/format_specs/ModelSpecification.md)
+format](https://github.com/cornerstone-data/useeior/blob/master/format_specs/ModelSpecification.md)
 pertaining to the `useeior` release version that is being used to
 generate the factors.

--- a/model-specs/README.md
+++ b/model-specs/README.md
@@ -8,7 +8,7 @@ Directory of model specifications for these models.
 |:-----------------------|--------------:|------------------------------:|-------------:|-----------------------------:|
 | USEEIOv2.1.19-GHG      |           411 |                     Commodity |         2012 |                         2019 |
 | USEEIOv2.2.22-GHG      |           402 |                     Commodity |         2017 |                         2022 |
-| USEEIOv2.5.1-phoebe-23 |           402 |                     Commodity |         2017 |                         2023 |
+| USEEIOv2.5.1-phoebe-23 |           408 |                     Commodity |         2017 |                         2023 |
 
 The model specification files use the [useeior Model Specification
 format](https://github.com/USEPA/useeior/blob/master/format_specs/ModelSpecification.md)

--- a/model-specs/USEEIOv2.5.1-phoebe-23.yml
+++ b/model-specs/USEEIOv2.5.1-phoebe-23.yml
@@ -1,0 +1,60 @@
+Model: "USEEIOv2.5.1-phoebe-23" 
+BaseIOSchema: 2017
+BaseIOLevel: "Detail"
+IOYear: 2017 # Year for IO data
+ModelRegionAcronyms: ["US"]
+ModelType: "EEIO"
+IODataSource: "BEA"
+BasePriceType: "PRO" #producer
+BasewithRedefinitions: FALSE
+CommodityorIndustryType: "Commodity"
+ScrapIncluded: FALSE
+DisaggregationSpecs: null
+
+SatelliteTable:
+  GHG:
+    FullName: "Greenhouse Gases"
+    Abbreviation: "GHG"
+    StaticSource: TRUE
+    StaticFile: "flowsa/FlowBySector/GHG_national_2023_m2_v2.1.0_70951b9.parquet"
+    FileLocation: "DataCommons"
+    DataYears: [2023]
+    Locations: ["US"]
+    SectorListSource: "NAICS"
+    SectorListYear: 2017
+    SectorListLevel: "6"
+    OriginalFlowSource: "FEDEFLv1.3.1"
+    ScriptFunctionCall: "getFlowbySectorCollapsed" #function to call for script
+    ScriptFunctionParameters: null
+    DataSources:
+      USEPA_GHG_2025:
+        Title: "GHG Inventory"
+        Author: "USEPA"
+        DataYear: 2023
+        URL: "https://www.edf.org/freedom-information-act-documents-epas-greenhouse-gas-inventory"
+        Primary: TRUE
+
+Indicators:
+  GreenhouseGases:
+    Name: "Greenhouse Gases"
+    Code: "GHG"
+    Group: "Impact Potential"
+    Unit: "kg CO2 eq"
+    SimpleUnit: "Kilograms Carbon Dioxide (CO2)"
+    SimpleName: "Greenhouse Gases"
+    StaticSource: TRUE
+    StaticFile: "lciafmt/ipcc/IPCC_v1.1.1_27ba917.parquet"
+    FileLocation: "DataCommons"
+    ScriptFunctionCall: "getImpactMethod" #function to call for script
+    ScriptFunctionParameters: 
+      indicators: ["AR6-100"]
+    DataSources:
+      IPCC_AR5:
+        Title: "IPCC Sixth Assessment Report: Direct Global Warming Potentials for 100 year time horizon"
+        Author: "IPCC"
+        DataYear: 2021
+        URL: ""
+        Primary: TRUE
+
+DemandVectors:
+    DefaultDemand: "DefaultDemandVectors" # Name of default demand vectors yml file

--- a/model-specs/USEEIOv2.5.1-phoebe-23.yml
+++ b/model-specs/USEEIOv2.5.1-phoebe-23.yml
@@ -9,14 +9,14 @@ BasePriceType: "PRO" #producer
 BasewithRedefinitions: FALSE
 CommodityorIndustryType: "Commodity"
 ScrapIncluded: FALSE
-DisaggregationSpecs: null
+DisaggregationSpecs: WasteDisaggregationDetail2017
 
 SatelliteTable:
   GHG:
     FullName: "Greenhouse Gases"
     Abbreviation: "GHG"
     StaticSource: TRUE
-    StaticFile: "flowsa/FlowBySector/GHG_national_2023_m2_v2.1.0_70951b9.parquet"
+    StaticFile: "flowsa/FlowBySector/GHG_national_2023_m2_v2.1.0_a37e031.parquet"
     FileLocation: "DataCommons"
     DataYears: [2023]
     Locations: ["US"]

--- a/model-specs/USEEIOv2.5.1-phoebe-23.yml
+++ b/model-specs/USEEIOv2.5.1-phoebe-23.yml
@@ -16,7 +16,7 @@ SatelliteTable:
     FullName: "Greenhouse Gases"
     Abbreviation: "GHG"
     StaticSource: TRUE
-    StaticFile: "GHG_national_2023_m2_v2.1.0_cda0cd5.parquet?download=1"
+    StaticFile: "GHG_national_2023_m2_v2.1.0_cda0cd5.parquet"
     FileLocation: "Zenodo17048864"
     DataYears: [2023]
     Locations: ["US"]

--- a/model-specs/USEEIOv2.5.1-phoebe-23.yml
+++ b/model-specs/USEEIOv2.5.1-phoebe-23.yml
@@ -16,8 +16,8 @@ SatelliteTable:
     FullName: "Greenhouse Gases"
     Abbreviation: "GHG"
     StaticSource: TRUE
-    StaticFile: "flowsa/FlowBySector/GHG_national_2023_m2_v2.1.0_a37e031.parquet"
-    FileLocation: "DataCommons"
+    StaticFile: "GHG_national_2023_m2_v2.1.0_cda0cd5.parquet?download=1"
+    FileLocation: "Zenodo17048864"
     DataYears: [2023]
     Locations: ["US"]
     SectorListSource: "NAICS"


### PR DESCRIPTION
Updates model to produce a release candidate of the v1.4.0 factors. Uses release candidate [2023 GHG sector attribution model output](https://zenodo.org/records/17048864) in the USEEIO model along with 2017 IO data with waste sector disaggregation and IPCC AR6 GWP indicators. Requires[ a new cornerstone-data development version of useeior](https://github.com/cornerstone-data/useeior/commit/61f2aaaba472da1dca6acc9400d18afa37581fae).  Repository readme updated to reflect Cornerstone publication retaining refs to original EPA publication.