### PR TITLE
Use 2024 USD

### DIFF
--- a/CalculateEmissionFactors.Rmd
+++ b/CalculateEmissionFactors.Rmd
@@ -4,7 +4,7 @@ output:
   md_document:
     variant: gfm
 params:
-  dollaryear: 2023
+  dollaryear: 2024
 ---
 
 Generate supply chain GHG emission factors for NAICS-6 Commodities using 2023 GHG data in CO2-equivalent and by gas.


### PR DESCRIPTION
Just changes default dollaryear to 2024.  Only works if useeior is built locally from https://github.com/cornerstone-data/useeior/commit/4007dad4afcfb8327daa3b7d5297b3717abf73f7 which is currently in https://github.com/cornerstone-data/useeior/tree/7-annual_data_update

